### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ MagicHomeAccessory.prototype.getServices = function() {
 
 MagicHomeAccessory.prototype.sendCommand = function(command, callback) {
     var exec = require('child_process').exec;
-    var cmd =  __dirname + '/flux_led.py ' + this.ip + ' ' + command;
+    var cmd =  __dirname + '/flux_led.py ' + this.ip + ' ' + command + ' -v';
     exec(cmd, callback);
 };
 


### PR DESCRIPTION
allowing flux_led.py to attempt to persist every update seems like it might be causing problems for some devices. my magic home device (a single channel controller: https://www.amazon.com/gp/product/B07WCVYB88/ref=ppx_yo_dt_b_asin_title_o02_s02?ie=UTF8&psc=1) initially worked great, but adjusting the slider repeatedly seemed to cause it to fail. It wouldn't work even after power cycles. running flux_led.py in volatile mode seemed to fix it. Some googling also found someone suggesting that constantly persisting  on these devices will damage the nvram: https://pbxinaflash.com/community/threads/onair-light.19085/

the simple fix would be to always run this in volatile mode, or maybe provide the option on a per-device basis in the config file